### PR TITLE
68 share todo reminder function

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,6 +9,8 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { StatusBar } from 'expo-status-bar';
 import React, { useEffect, useState } from 'react';
 import Toast, { BaseToast } from 'react-native-toast-message';
+import { reminder } from './assets';
+import { shareItem_db } from './hooks/firebase/ShareHooks';
 import { loginUser } from './hooks/firebase/UserHooks';
 import { checkUserData, getUserData } from './hooks/StorageHooks';
 import { Login } from './pages/Login';
@@ -19,6 +21,7 @@ import { SettingsProvider } from './src/contexts/SettingsContext';
 import { UserProvider } from './src/contexts/UserContext';
 
 const App = () => {
+  shareItem_db('VjaFj8zqnUsL14O334Hu', 'reminder', 'Felix@fis.com');
   const [loggedIn, setLoggedIn] = useState(false);
   useEffect(() => {
     checkUserData().then((boolean) => {

--- a/App.tsx
+++ b/App.tsx
@@ -21,7 +21,6 @@ import { SettingsProvider } from './src/contexts/SettingsContext';
 import { UserProvider } from './src/contexts/UserContext';
 
 const App = () => {
-  shareItem_db('VjaFj8zqnUsL14O334Hu', 'reminder', 'Felix@fis.com');
   const [loggedIn, setLoggedIn] = useState(false);
   useEffect(() => {
     checkUserData().then((boolean) => {
@@ -29,6 +28,7 @@ const App = () => {
         getUserData().then((data) => {
           loginUser(data).then(() => {
             setLoggedIn(true);
+            shareItem_db('5oC6i88nhfdXXse9udAA', 'Felix@fis.com');
           });
         });
       }

--- a/hooks/firebase/ReminderHooks.ts
+++ b/hooks/firebase/ReminderHooks.ts
@@ -17,6 +17,7 @@ export const createReminder_DB = async ({
       description: description,
       createdBy: user.uid,
       remindAt: remindAt,
+      sharedWith: [],
     });
     return {
       title: title,

--- a/hooks/firebase/ShareHooks.ts
+++ b/hooks/firebase/ShareHooks.ts
@@ -1,0 +1,44 @@
+import { fetchSignInMethodsForEmail } from 'firebase/auth';
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  setDoc,
+  updateDoc,
+} from 'firebase/firestore';
+import { reminder } from '../../assets';
+import { auth, db } from '../../config/firebaseConfig';
+import { remindersRef } from './ReminderHooks';
+
+export const shareItem_db = async (itemID, itemType: string, receiverEmail) => {
+  const users = [];
+
+  const querySnapshot = await getDocs(collection(db, 'users'));
+  querySnapshot.forEach((doc) => {
+    users.push({ ...doc.data(), id: doc.id });
+  });
+
+  try {
+    const receiverUser = users.find((doc) => doc.email === receiverEmail);
+    if (itemType === 'reminder') {
+      const docRef = doc(db, 'reminders', itemID);
+      const reminder = await getDoc(docRef);
+      const newData = await reminder.data();
+      const isSharedWithUser = newData.sharedWith.find(
+        (sharedItem) => sharedItem.receiverID === receiverUser.id
+      );
+      if (isSharedWithUser) return console.log('Already shared with this user');
+      newData.sharedWith = [
+        ...newData.sharedWith,
+        {
+          receiverID: receiverUser.id,
+          status: 'pending',
+        },
+      ];
+      updateDoc(docRef, newData);
+    }
+  } catch (e) {
+    console.log(e);
+  }
+};

--- a/types/FirebaseTypes.ts
+++ b/types/FirebaseTypes.ts
@@ -4,7 +4,7 @@
  * ? accepted
  * ? declined
  */
-// type Status = 'pending' | 'accepted' | 'declined';
+type Status = 'pending' | 'accepted';
 
 /**
  * * TodoList Data
@@ -32,12 +32,10 @@ export type Todo = {
  * TODO Share Data
  *
  */
-// type Share = {
-//   senderID: string;
-//   receiverID: string;
-//   reminderType: string;
-//   status: Status;
-// };
+type Share = {
+  receiverID: string;
+  status: Status;
+};
 
 /**
  * * Reminder Data
@@ -49,7 +47,7 @@ export type Reminder = {
   description: string;
   createdBy?: string;
   remindAt?: Date | string;
-  //sharedWith: Share[];
+  sharedWith?: Share[];
 };
 
 /**

--- a/types/FirebaseTypes.ts
+++ b/types/FirebaseTypes.ts
@@ -16,7 +16,7 @@ export type TodoList = {
   title: string;
   items: Todo[];
   createdBy?: string;
-  //   sharedWith: Share[];
+  sharedWith: Share[];
 };
 
 /**
@@ -32,7 +32,8 @@ export type Todo = {
  * TODO Share Data
  *
  */
-type Share = {
+export type Share = {
+  itemID: string;
   receiverID: string;
   status: Status;
 };


### PR DESCRIPTION
Provides a function for sharing an `ITEM` (reminder or to-do) to Firebase.

The function would take the necessary parameters, such as the itemID to be shared and the user email to whom it will be shared. Additionally, to prevent duplication, the function would include logic to check if the item has already been shared with the specified user. If the item has already been shared, the function will return an error message, otherwise, it will share the item with the user.